### PR TITLE
fix: change event name "vue3_study_message"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -794,7 +794,7 @@
             currentTarget.scrollIntoViewIfNeeded()
           }
 
-          window.addEventListener('message', ({ detail }) => {
+          window.addEventListener('vue3_study_message', ({ detail }) => {
             if (active) {
               console.log(detail)
               logs.value.push(detail)

--- a/docs/vue.global.js
+++ b/docs/vue.global.js
@@ -8468,7 +8468,7 @@ Server rendered element contains fewer child nodes than client vdom.`,
       }) => {
         if (container.classList.contains('done')) {
           globalThis.dispatchEvent(
-            new CustomEvent('message', {
+            new CustomEvent('vue3_study_message', {
               detail: {
                 scope,
                 type,

--- a/packages/runtime-core/src/renderer.ts
+++ b/packages/runtime-core/src/renderer.ts
@@ -1826,7 +1826,7 @@ function baseCreateRenderer(
     }) => {
       if (container.classList.contains('done')) {
         ;(globalThis as any).dispatchEvent(
-          new CustomEvent('message', {
+          new CustomEvent('vue3_study_message', {
             detail: {
               scope,
               type,


### PR DESCRIPTION
事件名"message"会被 `window.postMessage`方法触发，很多浏览器插件都会使用该方法，最好自定义事件名避免出现这种情况，否则会导致出现以下错误 ` window.addEventListener('message', ({ detail }) ...` 其中detail `undefined`

<img width="736" alt="SCR-20240619-nlkp" src="https://github.com/xachary/vue3-core-study/assets/17134256/25e6e96f-45e7-4a77-b228-0f5dd84cd815">

https://juejin.cn/post/7329194915682631718 下面评论看得出不止我一个人遇到这种情况😂